### PR TITLE
fix handling of no responders

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -2,6 +2,7 @@ package natschannel
 
 import (
 	"crypto/rand"
+	"fmt"
 	"testing"
 
 	"github.com/nats-io/nats.go"
@@ -70,14 +71,13 @@ func TestChannel_SendAndReceive(t *testing.T) {
 
 	// send some random data and check that we received it back
 	for i := 0; i < 1000; i++ {
-		// generate some random bytes
-		bytes := make([]byte, 128)
-		rand.Read(bytes)
+		bytes := []byte(fmt.Sprintf("data: %d", i+1))
 		// send
 		assert.Nil(t, channel.Send(bytes))
 		// receive
 		received, err := channel.Recv()
 		assert.Nil(t, err)
+		assert.False(t, len(received) == 0)
 		assert.Equal(t, bytes, received)
 	}
 }

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
         devShells.default = mkShell {
           packages = with pkgs;
             [
+              gcc
               delve # https://github.com/go-delve/delve
               go_1_19 # https://go.dev/
               gotools # https://go.googlesource.com/tools

--- a/test_helper.go
+++ b/test_helper.go
@@ -50,6 +50,12 @@ func pingPongTestServer(t *testing.T, s *server.Server, subject string, group st
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+
+	// helps ensure the server interest tree has been updated before any test code attempts to send to the subject
+	if err = conn.Flush(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
 	return sub
 }
 

--- a/test_helper.go
+++ b/test_helper.go
@@ -24,7 +24,7 @@ func client(t *testing.T, s *server.Server, opts ...nats.Option) *nats.Conn {
 	return nc
 }
 
-func pingPongTestServer(t *testing.T, s *server.Server, subject string, group string) *nats.Subscription {
+func pingPongTestResponder(t *testing.T, s *server.Server, subject string, group string) *nats.Subscription {
 	t.Helper()
 	conn := client(t, s)
 


### PR DESCRIPTION
- fix(nix): add missing gcc package to flake.nix
- fix: flush connection on ping pong server setup
- fix: capture and handle the case of no responders
- feat: better error and close handling
